### PR TITLE
Fix orders/add css

### DIFF
--- a/www/application/views/orders/add.php
+++ b/www/application/views/orders/add.php
@@ -1,11 +1,13 @@
 <div class="row">
-  <div class="col-md-5">
-    <div class="row">
-      <div class="col-md-2 selected-table"></div>
-      <div class="col-md-10 float-right">
-        <div class="btn btn-sm bg-red clearAllTables float-right"><i class="fas fa-broom"></i> Clear All</div>
-        <div class="btn btn-sm bg-purple openAssignModal float-right"><i class="fa fa-undo"></i> Replace / Merge</div>
-        <div class="btn btn-sm bg-yellow openTableModal float-right"><i class="far fa-hand-point-up"></i> Select Table</div>
+  <div class="col-md-12">
+    <div class="pos-card pos-toolbar">
+      <div class="row">
+        <div class="col-md-2 selected-table"></div>
+        <div class="col-md-10 float-right toolbar-actions">
+          <div class="btn btn-sm bg-red clearAllTables float-right"><i class="fas fa-broom"></i> Clear All</div>
+          <div class="btn btn-sm bg-purple openAssignModal float-right"><i class="fa fa-undo"></i> Replace / Merge</div>
+          <div class="btn btn-sm bg-yellow openTableModal float-right"><i class="far fa-hand-point-up"></i> Select Table</div>
+        </div>
       </div>
     </div>
   </div>
@@ -13,6 +15,8 @@
 
 <div class="row">
     <div class="col-md-4 vertical-separator tbl">
+        <div class="pos-card">
+        <div class="pos-card-title">Order</div>
         <div class="row text-bold cart-header">
             <div class="col-sm-5 text-left">ITEM</div>
             <div class="col-sm-1 text-center">QTY</div>
@@ -22,28 +26,32 @@
             <div class="col-md-1 text-left"><i class="fa fa-2x fa-times deleteAll"></i></div>
         </div>
         <div id="items-cart"></div>
+        </div>
     </div>
-    <div class="col-md-2 vertical-separator">
+    <div class="col-md-3 vertical-separator">
+        <div class="pos-card keypad-card">
         <div class="row">
-            <div class="col-md-3 btn btn-default calc-btn" style='background-color:#fbf8cc;'>7</div>
-            <div class="col-md-3 btn btn-default calc-btn" style='background-color:#fde4cf;'>8</div>
-            <div class="col-md-3 btn btn-default calc-btn" style='background-color:#ffcfd2;'>9</div>
+            <div class="col-md-4 btn btn-default calc-btn" style='background-color:#fbf8cc;'>7</div>
+            <div class="col-md-4 btn btn-default calc-btn" style='background-color:#fde4cf;'>8</div>
+            <div class="col-md-4 btn btn-default calc-btn" style='background-color:#ffcfd2;'>9</div>
         </div>
         <div class="row">
-            <div class="col-md-3 btn btn-default calc-btn" style='background-color:#f1c0e8;'>4</div>
-            <div class="col-md-3 btn btn-default calc-btn" style='background-color:#cfbaf0;'>5</div>
-            <div class="col-md-3 btn btn-default calc-btn" style='background-color:#a3c4f3;'>6</div>
+            <div class="col-md-4 btn btn-default calc-btn" style='background-color:#f1c0e8;'>4</div>
+            <div class="col-md-4 btn btn-default calc-btn" style='background-color:#cfbaf0;'>5</div>
+            <div class="col-md-4 btn btn-default calc-btn" style='background-color:#a3c4f3;'>6</div>
         </div>
         <div class="row">
-            <div class="col-md-3 btn btn-default calc-btn" style='background-color:#90dbf4;'>1</div>
-            <div class="col-md-3 btn btn-default calc-btn" style='background-color:#8eecf5;'>2</div>
-            <div class="col-md-3 btn btn-default calc-btn" style='background-color:#98f5e1;'>3</div>
+            <div class="col-md-4 btn btn-default calc-btn" style='background-color:#90dbf4;'>1</div>
+            <div class="col-md-4 btn btn-default calc-btn" style='background-color:#8eecf5;'>2</div>
+            <div class="col-md-4 btn btn-default calc-btn" style='background-color:#98f5e1;'>3</div>
         </div>
         <div class="row">
-            <div class="col-md-3 btn btn-default calc-btn" style='background-color:#b9fbc0;'>0</div>
-            <div class="col-md-6 btn btn-success nocalc-btn save">Save</div>
+            <div class="col-md-4 btn btn-default calc-btn" style='background-color:#b9fbc0;'>0</div>
+            <div class="col-md-8 btn btn-success nocalc-btn save">Save</div>
+        </div>
         </div>
 
+        <div class="pos-card customer-card">
         <div class="row">
             <div class="col-md-12">
                 <label for="popup_customer">Customer:</label>
@@ -59,15 +67,19 @@
                 <input type="text" id="popup_payment_mode" class="form-control cursor-pointer" value="CASH" data-toggle="modal" data-target="#paymentModeModal" readonly>
             </div>
         </div>
+        </div>
         
     </div>
-    <div class="col-md-6" id="categories">
+    <div class="col-md-5" id="categories">
+        <div class="pos-card">
         <div class="row" style="position:relative;">
             <div class="col-sm-12"><h3>Select Category</h3></div>
             <div class="target"></div>
         </div>
+        </div>
     </div>
-    <div class="col-md-6 d-none" id="products">
+    <div class="col-md-5 d-none" id="products">
+        <div class="pos-card">
         <div class="row">
             <div class="col-sm-12">
                 <h3><span class='category-name'></span>
@@ -75,6 +87,7 @@
                 </h3>
             </div>
             <div class="target"></div>
+        </div>
         </div>
     </div>
     <div id="addons-block" class="d-none">

--- a/www/assets/css/pos.css
+++ b/www/assets/css/pos.css
@@ -6,6 +6,7 @@
     width: 100px;
     height: 100px;
     display: inline-table;
+    position: relative;
 }
 
 .pos-btn img {
@@ -22,6 +23,7 @@
     height: 70px;
     display: inline-table;
     margin-right: 2px;
+    position: relative;
 }
 
 .addon-btn img {
@@ -261,4 +263,9 @@
 	font-size: 48px;
 	font-family: "Digital-7 Mono";
     text-align: right;
+}
+
+/* Visual separators for orders/add layout columns */
+.vertical-separator {
+    border-right: 1px solid #afbec0;
 }

--- a/www/assets/css/pos.css
+++ b/www/assets/css/pos.css
@@ -269,3 +269,27 @@
 .vertical-separator {
     border-right: 1px solid #afbec0;
 }
+
+/* POS Cards */
+.pos-card {
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 10px;
+    margin-bottom: 10px;
+}
+.pos-card-title {
+    font-weight: bold;
+    border-bottom: 1px solid #e5e7eb;
+    padding-bottom: 5px;
+    margin-bottom: 8px;
+}
+.pos-toolbar .toolbar-actions .btn {
+    margin-left: 6px;
+}
+.keypad-card .btn {
+    margin-bottom: 6px;
+}
+.customer-card label {
+    font-weight: bold;
+}


### PR DESCRIPTION
Redesign `orders/add` layout to a 3-column Point-of-Sale (POS) structure to improve user experience and visual clarity.

This PR introduces a new `pos-card` based layout for the `orders/add` page, organizing it into three distinct columns for order items, keypad/customer details, and product/category selection. It also includes CSS fixes for `.pos-btn` and `.addon-btn` overlays and adds a `.vertical-separator` for better column distinction.

---
<a href="https://cursor.com/background-agent?bcId=bc-04de9491-990c-42c9-bd44-0bd52120d9fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04de9491-990c-42c9-bd44-0bd52120d9fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

