### PR TITLE
Fix orders/add product layout

### DIFF
--- a/www/application/views/orders/add.php
+++ b/www/application/views/orders/add.php
@@ -63,7 +63,7 @@
     <div class="col-md-6" id="categories">
         <div class="row" style="position:relative;">
             <div class="col-sm-12"><h3>Select Category</h3></div>
-            <div class="target"></div>
+            <div class="target d-flex flex-wrap"></div>
         </div>
     </div>
     <div class="col-md-6 d-none" id="products">
@@ -73,12 +73,12 @@
                     <div class='backToCategories cursor-pointer float-right'><i class="fa fa-chevron-left"></i> Back</div>
                 </h3>
             </div>
-            <div class="target"></div>
+            <div class="target d-flex flex-wrap"></div>
         </div>
-    </div>
-    <div id="addons-block" class="d-none">
-        <div class="content"></div>
-        <div id="hideshow"><i class="fa fa-2x fa-chevron-left d-none"></i><i class="fa fa-2x fa-chevron-right"></i></div>
+        <div id="addons-block" class="d-none">
+            <div class="content d-flex flex-wrap"></div>
+            <div id="hideshow"><i class="fa fa-2x fa-chevron-left d-none"></i><i class="fa fa-2x fa-chevron-right"></i></div>
+        </div>
     </div>
 </div>
 

--- a/www/assets/js/pages/orders_add_vue.js
+++ b/www/assets/js/pages/orders_add_vue.js
@@ -129,12 +129,12 @@
         app.mount(categoriesRoot);
     }
 
-    // Mount products section (re-uses existing container)
-    const productsRoot = document.querySelector('#products');
-    if(productsRoot){
-        const app2 = createApp(Products);
-        app2.mount(productsRoot);
-    }
+    // Mount products section is disabled to avoid duplicate rendering and layout conflicts
+    // const productsRoot = document.querySelector('#products');
+    // if(productsRoot){
+    //     const app2 = createApp(Products);
+    //     app2.mount(productsRoot);
+    // }
 
 })();
 


### PR DESCRIPTION
Fix the incorrect layout of product categories and products on the `orders/add` page.

The previous layout suffered from misaligned elements and lacked responsiveness. This PR resolves these issues by applying flex-wrapping to the product and category containers, repositioning the addons block for proper alignment, and disabling a duplicate Vue Products component to prevent rendering conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf87c780-7fc6-4655-82c8-54f9e15a26c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf87c780-7fc6-4655-82c8-54f9e15a26c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

